### PR TITLE
Add parser callbacks

### DIFF
--- a/src/warcbench/__init__.py
+++ b/src/warcbench/__init__.py
@@ -19,6 +19,7 @@ class WARCParser:
         filters=None,
         record_handlers=None,
         unparsable_line_handlers=None,
+        parser_callbacks=None,
     ):
         #
         # Validate Options
@@ -50,6 +51,7 @@ class WARCParser:
                     filters=filters,
                     record_handlers=record_handlers,
                     unparsable_line_handlers=unparsable_line_handlers,
+                    parser_callbacks=parser_callbacks,
                 )
             case "content_length":
                 self._parser = ContentLengthWARCParser(
@@ -66,6 +68,7 @@ class WARCParser:
                     filters=filters,
                     record_handlers=record_handlers,
                     unparsable_line_handlers=unparsable_line_handlers,
+                    parser_callbacks=parser_callbacks,
                 )
             case _:
                 supported_parsing_styles = ["delimiter", "content_length"]

--- a/src/warcbench/scripts/example.py
+++ b/src/warcbench/scripts/example.py
@@ -47,6 +47,9 @@ def parse_example() -> None:
             record_handlers=[
                 # print_record_attribute('length')
             ],
+            parser_callbacks=[
+                # lambda parser: print(len(parser.records))
+            ],
             # unparsable_line_handlers=[
             #     lambda line: print(len(line.bytes))
             # ]


### PR DESCRIPTION
As discussed, adding a generic parser callback, that runs after the last WARC record has been yielded, will give developers more options for easily plugging in custom logic... for example, printing the number of records parsed.